### PR TITLE
Add more convenience functions and expand docs

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -243,6 +243,16 @@ Efforts will be made to move to a disk-backed store.
 
 :::
 
+Similarly, if cell-level data is desired, RME requires that the simulations be run on a
+year-by-year basis, with results extracted every time step.
+
+::: info
+
+TODO: Example of running RME on a year-by-year basis.
+
+:::
+
+
 ```julia
 name = "Example"       # Name to associate with this set of runs
 start_year = 2022

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -60,7 +60,7 @@ A full list of ReefModEngine.jl functions is provided in [API](@ref API).
 set_option("thread_count", 2)
 set_option("restoration_dhw_tolerance_outplants", 3)
 set_option("use_fixed_seed", 1)  # turn on use of a fixed seed value
-set_option("fixed_seed", 123.0)  # set the fixed seed value
+set_option("fixed_seed", 123)  # set the fixed seed value
 
 # Get list of reef ids as specified by ReefMod Engine
 reef_id_list = reef_ids()

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -1,4 +1,92 @@
-# Usage example
+# Getting Started
+
+## Preface
+
+ReefMod is a coral ecology model developed at the University of Queensland with more than
+20 years of development history. The original ReefMod model was written in MATLAB.
+ReefMod has been ported to C++ to address issues and concerns around computational
+efficiency. This port is referred to as the ReefMod Engine (RME).
+
+This package, ReefModEngine.jl, provides a Julia interface to the RME, leveraging Julia's
+first-class language interoperability support.
+
+To avoid confusion, the following naming conventions are used when referring to each.
+
+- The original MATLAB implementation is _always_ referred to as ReefMod.
+- The C++ port, ReefMod Engine (RME), is _always_ referred to as RME.
+- This package, ReefModEngine.jl, is _always_ referred to by its full name.
+
+## Initialization
+
+Before anything can be done, the RME library has to first be initialized.
+
+```julia
+# Initialize RME (may take a minute or two)
+init_rme("path to RME directory")
+# [ Info: Loaded RME 1.0.28
+```
+
+## Setting RME options
+
+RME is able to run multiple simulations at the same time via multi-threading.
+The recommended value according to the RME documentation is a number equal to or less than
+the number of available CPU cores.
+
+```julia
+# Set to use two threads
+set_option("thread_count", 2)
+```
+
+ReefModEngine.jl provides a few convenience functions to interact with RME.
+All other RME functions are available for direct use via the `@RME` macro.
+Care needs to be taken to call RME functions. Specifically:
+
+- The exact types as expected by the RME function needs to be used.
+- No protection is provided if mismatched types are used (e.g., passing in a Float instead of an Integer)
+
+A full list of ReefModEngine.jl functions is provided in [API](@ref API).
+
+## Short list of RME interface functions
+
+```julia
+# Set RME options by its config name
+# See RME documentation for list of available options
+set_option("thread_count", 2)
+set_option("restoration_dhw_tolerance_outplants", 3)
+
+# Get list of reef ids as specified by ReefMod Engine
+reef_id_list = reef_ids()
+
+# Retrieve list of reef areas in km² (in same order as reef ids)
+reef_area_km² = reef_areas()
+
+# Retrieve list of reef areas in km² for specified reefs by their ids
+first_10_reef_area_km² = reef_areas(reef_id_list[1:10])
+
+# Find the index position of a reef by its GBRMPA ID
+match_id("10-330")
+#  1
+
+# Calculate the minimum area required (in km²) at a given density
+area_needed(100_000, 6.8)
+
+# Create a convenient result store to help extract data from RME
+result_store = ResultStore(start_year, end_year, n_reefs, reps)
+
+# Collect and store results
+collect_all_results!(result_store, start_year, end_year, reps)
+
+# Initialize RME runs
+run_init()
+```
+
+If more runs are desired after running RME, it is required to first clear RME's state.
+
+```julia
+reset_rme()
+```
+
+## Example usage
 
 ```julia
 using ReefModEngine
@@ -17,29 +105,30 @@ set_option("thread_count", 2)
 # the id list file (the file is found under `data_files/id` of the RME data set)
 deploy_loc_details = CSV.read("target_locations.csv", DataFrame, header=["index_id", "reef_id"])
 
-name = "Example"
-start_year = 2022
-end_year = 2099
-RCP_scen = "SSP 2.45"
-gcm = "CNRM_ESM2_1"
-reps = 2
-n_reefs = 3806
-
-# Get list of reef ids as specified by ReefMod Engine
-reef_id_list = reef_ids()
-
 # Reef indices and IDs
 target_reef_idx = deploy_loc_details.index_id
 target_reef_ids = deploy_loc_details.reef_id
 n_target_reefs = length(target_reef_idx)
 
+# Get list of reef ids as specified by ReefMod Engine
+reef_id_list = reef_ids()
+
+name = "Example"       # Name to associate with this set of runs
+start_year = 2022
+end_year = 2099
+RCP_scen = "SSP 2.45"  # RCP/SSP scenario to use
+gcm = "CNRM_ESM2_1"    # The base Global Climate Model (GCM)
+reps = 2               # Number of repeats: number of random environmental sequences to run
+n_reefs = length(reef_id_list)
+
 # Get reef areas from RME
-reef_areas = zeros(n_reefs)
-@RME reefAreasKm2(reef_areas::Ptr{Cdouble}, n_reefs::Cint)::Cint
+reef_areas = reef_areas()
 
 # Get list of areas for the target reefs
-target_reef_areas_km² = reef_areas[target_reef_idx]
-d_density_m² = 6.8  # coral seeding density (per m²)
+target_reef_areas_km² = reef_areas(id_list)
+
+# Define coral outplanting density (per m²)
+d_density_m² = 6.8
 
 # Initialize result store
 result_store = ResultStore(start_year, end_year, n_reefs, reps)
@@ -60,8 +149,7 @@ result_store = ResultStore(start_year, end_year, n_reefs, reps)
 # species : (78, 3806, 6, 2)
 
 @info "Starting runs"
-@RME ivRemoveAll()::Cvoid
-@RME reefSetRemoveAll()::Cint
+reset_rme()  # Reset RME to clear any previous runs
 
 # Note: if the Julia runtime crashes, check that the specified data file location is correct
 @RME runCreate(name::Cstring, start_year::Cint, end_year::Cint, RCP_scen::Cstring, gcm::Cstring, reps::Cint)::Cint
@@ -78,7 +166,8 @@ set_outplant_deployment!("outplant_iv_2026", "iv_moore", 100_000, 2026, target_r
 set_outplant_deployment!("outplant_iv_2027", "iv_moore", 500_000, 2027, target_reef_areas_km², d_density_m²)
 set_outplant_deployment!("outplant_iv_2028_2031", "iv_moore", Int64(1.1 * 1e6), Int64(1.1 * 1e6)*3, 2028, 2031, 1, target_reef_areas_km², d_density_m²)
 
-@RME runInit()::Cint
+# Initialize RME runs as defined above
+run_init()
 
 # Run all years and all reps
 @time @RME runProcess()::Cint

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -32,6 +32,11 @@ RME is able to run multiple simulations at the same time via multi-threading.
 The recommended value according to the RME documentation is a number equal to or less than
 the number of available CPU cores.
 
+```julia
+# Set to use two threads
+set_option("thread_count", 2)
+```
+
 ::: tip
 
 Do remember, however, that each process requires memory as well, so the total number of
@@ -40,10 +45,7 @@ threads should not exceed `ceil([available memory] / [memory required per thread
 The required memory depends on a number of factors including the represented grid size.
 As a general indication, RME's memory use is ~4-5GB for a single run with a 10x10 grid.
 
-```julia
-# Set to use two threads. Expect ~16GB of memory to be required.
-set_option("thread_count", 2)
-```
+:::
 
 ReefModEngine.jl provides a few convenience functions to interact with RME.
 All other RME functions are available for direct use via the `@RME` macro.
@@ -234,6 +236,8 @@ to run each replicate individually and store results as they complete.
 ReefModEngine.jl's result store is currently memory-based as well, so the only advantage
 to this approach currently is avoiding storing results when they are no longer necessary.
 Efforts will be made to move to a disk-backed store.
+
+:::
 
 ```julia
 name = "Example"       # Name to associate with this set of runs

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -84,7 +84,7 @@ match_id("10-330")
 area_needed(100_000, 6.8)
 
 # Create a convenient result store to help extract data from RME
-result_store = ResultStore(start_year, end_year, n_reefs, reps)
+result_store = ResultStore(start_year, end_year, reps)
 
 # Collect results for runs 1, 3 and 5 only
 collect_rep_results!(result_store, start_year, end_year, [1,3,5])
@@ -156,7 +156,7 @@ target_reef_areas_km² = reef_areas(target_reef_ids)
 d_density_m² = 6.8
 
 # Initialize result store
-result_store = ResultStore(start_year, end_year, n_reefs, reps)
+result_store = ResultStore(start_year, end_year, reps)
 # Outputs:
 # ReefModEngine Result Store
 #
@@ -263,7 +263,7 @@ reps = 4               # Number of repeats: number of random environmental seque
 n_reefs = length(reef_id_list)
 
 # Initialize result store
-result_store = ResultStore(start_year, end_year, n_reefs, reps)
+result_store = ResultStore(start_year, end_year, reps)
 
 set_option("use_fixed_seed", 1)  # Turn on use of a fixed seed value
 set_option("fixed_seed", 123.0)  # Set the fixed seed value

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -75,7 +75,8 @@ first_10_reef_area_km² = reef_areas(reef_id_list[1:10])
 match_id("10-330")
 #  1
 
-# Calculate the minimum area required (in km²) at a given density
+# Calculate the minimum area required (in km²) to deploy a number of corals
+# at a given density
 area_needed(100_000, 6.8)
 
 # Create a convenient result store to help extract data from RME

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -36,7 +36,9 @@ the number of available CPU cores.
 
 Do remember, however, that each process requires memory as well, so the total number of
 threads should not exceed `ceil([available memory] / [memory required per thread])`.
-As a general indication, RME's memory use is ~8-9GB for a single run.
+
+The required memory depends on a number of factors including the represented grid size.
+As a general indication, RME's memory use is ~4-5GB for a single run with a 10x10 grid.
 
 ```julia
 # Set to use two threads. Expect ~16GB of memory to be required.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -209,6 +209,7 @@ run_init()
 collect_all_results!(result_store, start_year, end_year, reps)
 
 # Save results to matfile with entries (matching ReefMod Engine standard names)
+# Defaults to "RME_outcomes_[today's date].mat"
 # coral_cover_ref
 # coral_cover_iv
 # dhw_ref
@@ -226,6 +227,9 @@ collect_all_results!(result_store, start_year, end_year, reps)
 # species_ref
 # species_iv
 save_to_mat(result_store)
+
+# A custom path can also be specified
+# save_to_mat(result_store, "../output/my_results.mat")
 ```
 
 The RME stores all data in memory, so for larger number of replicates it may be better

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -183,9 +183,17 @@ set_option("restoration_dhw_tolerance_outplants", 3)
 
 # Deployments occur between 2025 2030
 # Year 1: 100,000 outplants; Year 2: 500,000; Year 3: 1,1M; Year 4: 1,1M; Year 5: 1,1M and Year 6: 1,1M.
-set_outplant_deployment!("outplant_iv_2026", "iv_example", 100_000, 2026, target_reef_areas_km², d_density_m²)
-set_outplant_deployment!("outplant_iv_2027", "iv_example", 500_000, 2027, target_reef_areas_km², d_density_m²)
-set_outplant_deployment!("outplant_iv_2028_2031", "iv_example", Int64(1.1 * 1e6), Int64(1.1 * 1e6)*3, 2028, 2031, 1, target_reef_areas_km², d_density_m²)
+# set_outplant_deployment!("outplant_iv_2026", "iv_example", 100_000, 2026, target_reef_areas_km², d_density_m²)
+# set_outplant_deployment!("outplant_iv_2027", "iv_example", 500_000, 2027, target_reef_areas_km², d_density_m²)
+
+# Can also specify deployments to occur over a range of years
+# set_outplant_deployment!("outplant_iv_2028_2031", "iv_example", Int64(1.1e6), Int64(1.1e6), 2028, 2031, 1, target_reef_areas_km², d_density_m²)
+
+# If no deployment density is specified, ReefModEngine.jl will attempt to calculate the
+# most appropriate density to maintain the specified grid size (defaulting to 10x10).
+set_outplant_deployment!("outplant_iv_2026", "iv_example", 100_000, 2026, target_reef_areas_km²)
+set_outplant_deployment!("outplant_iv_2027", "iv_example", 500_000, 2027, target_reef_areas_km²)
+set_outplant_deployment!("outplant_iv_2028_2031", "iv_example", Int64(1.1e6), 2028, 2031, 1, target_reef_areas_km²)
 
 # Initialize RME runs as defined above
 run_init()

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -36,7 +36,7 @@ the number of available CPU cores.
 
 Do remember, however, that each process requires memory as well, so the total number of
 threads should not exceed `ceil([available memory] / [memory required per thread])`.
-As a general indication, RME's memory use is ~8GB for a single run.
+As a general indication, RME's memory use is ~8-9GB for a single run.
 
 ```julia
 # Set to use two threads. Expect ~16GB of memory to be required.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,7 @@
 
 A Julia interface to the ReefMod Engine (RME) C++ API.
 
-Targets RME v1.0, and provides some convenience functions for outplanting interventions.
+Targets RME v1.0, and provides some convenience functions to interact with the RME.
 All other functions are accessible via the `@RME` macro.
 
 The RME library, accompanying dataset, and RME documentation has to be requested from RME developers.

--- a/src/ReefModEngine.jl
+++ b/src/ReefModEngine.jl
@@ -35,12 +35,12 @@ end
 
 # Set up and initialization
 export
-    init_rme, reset_rme, @RME, set_option
+    init_rme, reset_rme, @RME, set_option, run_init
 
 # Convenience/utility methods
 export
     reef_ids, deployment_area, set_outplant_deployment!,
-    match_id, match_ids
+    match_id, match_ids, reef_areas
 
 # IO
 export

--- a/src/ReefModEngine.jl
+++ b/src/ReefModEngine.jl
@@ -44,6 +44,6 @@ export
 
 # IO
 export
-    ResultStore, collect_all_results!, save_to_mat
+    ResultStore, collect_all_results!, collect_rep_results!, save_to_mat
 
 end

--- a/src/ResultStore.jl
+++ b/src/ResultStore.jl
@@ -15,6 +15,9 @@ struct ResultStore
     reps::Int64
 end
 
+function ResultStore(start_year, end_year, reps)
+    return ResultStore(start_year, end_year, 3806, reps)
+end
 function ResultStore(start_year, end_year, n_reefs, reps)
     year_range = (end_year - start_year) + 1
 
@@ -120,7 +123,7 @@ function collect_all_results!(
     rs::ResultStore, start_year::Int64, end_year::Int64, reps::Int64
 )::Nothing
     # Temporary data store for results
-    n_reefs = size(rs.cover[:ref], 2)
+    n_reefs = 3806
     n_species = size(rs.species[:ref], 3)
     tmp = zeros(n_reefs)
 
@@ -327,7 +330,7 @@ function collect_rep_results!(
     rs::ResultStore, start_year::Int64, end_year::Int64, reps::Vector{Int64}
 )::Nothing
     # Temporary data store for results
-    n_reefs = size(rs.cover[:ref], 2)
+    n_reefs = 3806
     n_species = size(rs.species[:ref], 3)
     tmp = zeros(n_reefs)
 

--- a/src/ResultStore.jl
+++ b/src/ResultStore.jl
@@ -105,10 +105,20 @@ function Base.show(io::IO, mime::MIME"text/plain", rs::ResultStore)::Nothing
 end
 
 
+"""
+    collect_all_results!(rs::ResultStore, start_year::Int64, end_year::Int64, reps::Int64)::Nothing
+
+Collect results for all runs/replicates.
+
+# Arguments
+- `rs` : Result store to save data to
+- `start_year` : Collect data from this year
+- `end_year` : Collect data to this year
+- `reps` : Total number of expected replicates
+"""
 function collect_all_results!(
     rs::ResultStore, start_year::Int64, end_year::Int64, reps::Int64
 )::Nothing
-
     # Temporary data store for results
     n_reefs = size(rs.cover[:ref], 2)
     n_species = size(rs.species[:ref], 3)
@@ -301,6 +311,215 @@ function collect_all_results!(
 
     return nothing
 end
+
+"""
+    collect_rep_results!(rs::ResultStore, start_year::Int64, end_year::Int64, reps::Vector{Int64})::Nothing
+
+Collect results for a specific replicate.
+
+# Arguments
+- `rs` : Result store to save data to
+- `start_year` : Collect data from this year
+- `end_year` : Collect data to this year
+- `reps` : Specific replicates to save data for
+"""
+function collect_rep_results!(
+    rs::ResultStore, start_year::Int64, end_year::Int64, reps::Vector{Int64}
+)::Nothing
+    # Temporary data store for results
+    n_reefs = size(rs.cover[:ref], 2)
+    n_species = size(rs.species[:ref], 3)
+    tmp = zeros(n_reefs)
+
+    for r in reps
+        for (i, yr) in enumerate(start_year:end_year)
+            # "" : Can specify name of a reef set, or empty to indicate all reefs
+            # 0 | 1 : without intervention; with intervention
+            @RME runGetData(
+                "coral_pct"::Cstring,
+                ""::Cstring,
+                0::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.cover[:ref][i, :, r] = tmp
+
+            @RME runGetData(
+                "coral_pct"::Cstring,
+                ""::Cstring,
+                1::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.cover[:iv][i, :, r] = tmp
+
+            @RME runGetData(
+                "max_dhw"::Cstring,
+                ""::Cstring,
+                0::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.dhw[:ref][i, :, r] = tmp
+
+            @RME runGetData(
+                "max_dhw"::Cstring,
+                ""::Cstring,
+                1::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.dhw[:iv][i, :, r] = tmp
+
+            @RME runGetData(
+                "dhw_loss_pct"::Cstring,
+                ""::Cstring,
+                0::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.dhw_mortality[:ref][i, :, r] = tmp
+
+            @RME runGetData(
+                "dhw_loss_pct"::Cstring,
+                ""::Cstring,
+                1::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.dhw_mortality[:iv][i, :, r] = tmp
+
+            @RME runGetData(
+                "cyclone_loss_pct"::Cstring,
+                ""::Cstring,
+                0::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.cyc_mortality[:ref][i, :, r] = tmp
+
+            @RME runGetData(
+                "cyclone_loss_pct"::Cstring,
+                ""::Cstring,
+                1::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.cyc_mortality[:iv][i, :, r] = tmp
+
+            @RME runGetData(
+                "cyclone_cat"::Cstring,
+                ""::Cstring,
+                0::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.cyc_cat[:ref][i, :, r] = tmp
+
+            @RME runGetData(
+                "cyclone_cat"::Cstring,
+                ""::Cstring,
+                1::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.cyc_cat[:iv][i, :, r] = tmp
+
+            # CoTS
+            @RME runGetData(
+                "cots_per_ha"::Cstring,
+                ""::Cstring,
+                0::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.cots[:ref][i, :, r] = tmp
+
+            @RME runGetData(
+                "cots_per_ha"::Cstring,
+                ""::Cstring,
+                1::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.cots[:iv][i, :, r] = tmp
+
+            @RME runGetData(
+                "cots_loss_pct"::Cstring,
+                ""::Cstring,
+                0::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.cots_mortality[:ref][i, :, r] = tmp
+
+            @RME runGetData(
+                "cots_loss_pct"::Cstring,
+                ""::Cstring,
+                1::Cint,
+                yr::Cint,
+                r::Cint,
+                tmp::Ref{Cdouble},
+                n_reefs::Cint
+            )::Cint
+            rs.cots_mortality[:iv][i, :, r] = tmp
+
+            for sp in 1:n_species
+                @RME runGetData(
+                    "species_$(sp)_pct"::Cstring,
+                    ""::Cstring,
+                    0::Cint,
+                    yr::Cint,
+                    r::Cint,
+                    tmp::Ref{Cdouble},
+                    n_reefs::Cint
+                )::Cint
+                rs.species[:ref][i, :, sp, r] = tmp
+
+                @RME runGetData(
+                    "species_$(sp)_pct"::Cstring,
+                    ""::Cstring,
+                    1::Cint,
+                    yr::Cint,
+                    r::Cint,
+                    tmp::Ref{Cdouble},
+                    n_reefs::Cint
+                )::Cint
+                rs.species[:iv][i, :, sp, r] = tmp
+            end
+        end
+    end
+
+    return nothing
+end
+
+
 
 function _extract_all_results(rs)
     all_res = Dict(

--- a/src/deployment.jl
+++ b/src/deployment.jl
@@ -27,6 +27,7 @@ function deployment_area(n_corals::Int64, max_n_corals::Int64, density::Float64,
 
         # RME supported cell sizes (N by N)
         # Determine smallest appropriate grid size when larger grid sizes are set.
+        # Larger grid sizes = greater cell resolution, incurring larger runtime costs.
         p::Vector{Int64} = Int64[10, 20, 25, 30, 36, 43, 55, 64, 85, 100]
         n_cells::Int64 = try
             first(p[p.>=cell_res])
@@ -38,7 +39,7 @@ function deployment_area(n_corals::Int64, max_n_corals::Int64, density::Float64,
         opt::String = "RMFAST$(n_cells)"
         @RME setOptionText("processing_method"::Cstring, opt::Cstring)::Cint
 
-        @warn "Insufficient number of treatment cells. Adjusting grid size.\nSetting grid to $(n_cells) by $(n_cells) cells"
+        @warn "Insufficient number of treatment cells. Adjusting grid size.\nSetting grid to $(n_cells) by $(n_cells) cells\nThe larger the grid size, the longer the runtime."
     end
 
     return d_area_pct, mod_density

--- a/src/deployment.jl
+++ b/src/deployment.jl
@@ -56,7 +56,19 @@ Set outplanting deployments for a single year.
 - `year` : Year to intervene
 - `area_km2` : Area to intervene [km²]
 - `density` : Stocking density of intervention [corals / m²]
+"""
+function set_outplant_deployment!(
+    name::String,
+    reefset::String,
+    n_corals::Int64,
+    year::Int64,
+    area_km2::Vector{Float64},
+    density::Float64
+)::Nothing
+    set_outplant_deployment!(name, reefset, n_corals, n_corals, year, year, 1, area_km2, density)
+end
 
+"""
     set_outplant_deployment!(name::String, reefset::String, n_corals::Int64, max_effort::Int64, first_year::Int64, last_year::Int64, year_step::Int64, area_km2::Vector{Float64}, density::Float64)::Nothing
 
 Set outplanting deployments across a range of years.
@@ -72,16 +84,6 @@ Set outplanting deployments across a range of years.
 - `area_km2` : Intervention area [km²]
 - `density` : Stocking density of intervention [corals / m²]
 """
-function set_outplant_deployment!(
-    name::String,
-    reefset::String,
-    n_corals::Int64,
-    year::Int64,
-    area_km2::Vector{Float64},
-    density::Float64
-)::Nothing
-    set_outplant_deployment!(name, reefset, n_corals, n_corals, year, year, 1, area_km2, density)
-end
 function set_outplant_deployment!(
     name::String,
     reefset::String,

--- a/src/deployment.jl
+++ b/src/deployment.jl
@@ -6,19 +6,20 @@ Determine deployment area for the expected number of corals to be deployed.
 # Arguments
 - `n_corals` : Number of corals,
 - `max_n_corals` : Expected maximum deployment effort (total number of corals in intervention set)
-- `density` : Stocking density
+- `density` : Stocking density per m²
 - `target_areas` : Available area at target location(s)
 
 # Returns
 Tuple
 - Percent area of deployment
-- modified stocking density
+- modified stocking density [currently no modifications are made]
 """
 function deployment_area(n_corals::Int64, max_n_corals::Int64, density::Float64, target_areas::Vector{Float64})::Tuple{Float64,Float64}
     req_area = area_needed(max_n_corals, density)
     mod_density = (n_corals * 0.5) / (req_area / m2_TO_km2)
-    d_area_pct = min((req_area / sum(target_areas)) * 100.0, 100.0)
+    deployment_area_pct = min((req_area / sum(target_areas)) * 100.0, 100.0)
 
+    # Adjust grid size if needed to simulate deployment area/percent
     min_cells::Int64 = 3
     if (RME_BASE_GRID_SIZE[] * req_area / sum(target_areas)) < min_cells
         # Determine new grid resolution in terms of number of N by N cells
@@ -42,7 +43,40 @@ function deployment_area(n_corals::Int64, max_n_corals::Int64, density::Float64,
         @warn "Insufficient number of treatment cells. Adjusting grid size.\nSetting grid to $(n_cells) by $(n_cells) cells\nThe larger the grid size, the longer the runtime."
     end
 
-    return d_area_pct, mod_density
+    return deployment_area_pct, mod_density
+end
+
+"""
+    deployment_area(max_n_corals::Int64, target_areas::Vector{Float64})::Tuple{Float64,Float64}
+
+Determine deployment area for given number of corals and target area, calculating the
+appropriate deployment density to maintain the specified grid size.
+"""
+function deployment_area(max_n_corals::Int64, target_areas::Vector{Float64})::Tuple{Float64,Float64}
+
+    min_cells::Int64 = 3
+    density::Float64 = 0.0
+    req_area::Float64 = 0.0
+    for d in reverse(0.05:0.1:13.0)
+        req_area = area_needed(max_n_corals, d)
+
+        if (RME_BASE_GRID_SIZE[] * req_area / sum(target_areas)) < min_cells
+            continue
+        end
+
+        density = d
+        break
+    end
+
+    if density == 0.0
+        throw(DomainError("Could not determine adequate deployment density: $((RME_BASE_GRID_SIZE[] * req_area / sum(target_areas)))"))
+    end
+
+    @info "Determined min. deployment density to be: $(density) / m²"
+
+    deployment_area_pct = min((req_area / sum(target_areas)) * 100.0, 100.0)
+
+    return deployment_area_pct, density
 end
 
 """
@@ -99,6 +133,63 @@ function set_outplant_deployment!(
     iv_type = "outplant"
 
     area_pct, mod_density = deployment_area(n_corals, max_effort, density, area_km2)
+
+    @RME ivAdd(name::Cstring, iv_type::Cstring, reefset::Cstring, first_year::Cint, last_year::Cint, year_step::Cint)::Cint
+    @RME ivSetOutplantAreaPct(name::Cstring, area_pct::Cdouble)::Cint
+    @RME ivSetOutplantCountPerM2(name::Cstring, mod_density::Cdouble)::Cint
+
+    return nothing
+end
+
+"""
+    set_outplant_deployment!(name::String, reefset::String, n_corals::Int64, year::Int64, area_km2::Vector{Float64})::Nothing
+
+Set outplanting deployments for a single year, automatically determining the coral
+deployment density to maintain the set grid size.
+
+# Arguments
+- `name` : Name to assign intervention event
+- `reefset` : Name of pre-defined list of reefs to intervene on
+- `n_corals` : Number of corals to outplant
+- `year` : Year to intervene
+- `area_km2` : Area to intervene [km²]
+"""
+function set_outplant_deployment!(
+    name::String,
+    reefset::String,
+    n_corals::Int64,
+    year::Int64,
+    area_km2::Vector{Float64}
+)::Nothing
+    set_outplant_deployment!(name, reefset, n_corals, year, year, 1, area_km2)
+end
+
+"""
+    set_outplant_deployment!(
+        name::String,
+        reefset::String,
+        max_effort::Int64,
+        first_year::Int64,
+        last_year::Int64,
+        year_step::Int64,
+        area_km2::Vector{Float64},
+    )::Nothing
+
+Set outplanting deployments across a range of years, automatically determining the
+coral deployment density to maintain the set grid size.
+"""
+function set_outplant_deployment!(
+    name::String,
+    reefset::String,
+    max_effort::Int64,
+    first_year::Int64,
+    last_year::Int64,
+    year_step::Int64,
+    area_km2::Vector{Float64},
+)::Nothing
+    iv_type = "outplant"
+
+    area_pct, mod_density = deployment_area(max_effort, area_km2)
 
     @RME ivAdd(name::Cstring, iv_type::Cstring, reefset::Cstring, first_year::Cint, last_year::Cint, year_step::Cint)::Cint
     @RME ivSetOutplantAreaPct(name::Cstring, area_pct::Cdouble)::Cint

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,7 +1,7 @@
 """
     area_needed(n_corals::Int64, density::Float64)::Float64
 
-Determine area needed to deploy the given number of corals at the specified density.
+Determine area (in km²) needed to deploy the given number of corals at the specified density.
 """
 function area_needed(n_corals::Int64, density::Float64)::Float64
     # ReefMod deploys twice a year so halve the number of corals to deploy
@@ -22,6 +22,30 @@ function reef_ids()::Vector{String}
     end
 
     return reef_id_list
+end
+
+"""
+    reef_areas()
+
+Retrieve all reef areas in km²
+"""
+function reef_areas()
+    n_reefs = 3806
+    reef_areas = zeros(n_reefs)
+    @RME reefAreasKm2(reef_areas::Ptr{Cdouble}, n_reefs::Cint)::Cint
+
+    return reef_areas
+end
+
+"""
+    reef_areas(id_list)
+
+Retrieve reef areas in km² for specified locations.
+"""
+function reef_areas(id_list)
+    areas = reef_areas()
+    reef_idx = match_ids(id_list)
+    return areas[reef_idx]
 end
 
 """

--- a/src/rme_init.jl
+++ b/src/rme_init.jl
@@ -12,6 +12,14 @@ function _associate_rme(rme_path::String)
     rme_path = replace(rme_path, "/" => path_separator, "\\" => path_separator)
     lib_path = joinpath(rme_path, "lib", "librme_ml$(libext)")
 
+    if !isdir(rme_path)
+        throw(ArgumentError("Provided path to RME does not exist: $(rme_path)"))
+    end
+
+    if !isfile(lib_path)
+        throw(ArgumentError("Could not find RME library: $(lib_path)"))
+    end
+
     if !@isdefined(RME)
         # For internal use
         @eval const RME_PATH = $(rme_path)

--- a/src/rme_init.jl
+++ b/src/rme_init.jl
@@ -54,6 +54,15 @@ function reset_rme()
     @RME reefSetRemoveAll()::Cint
 end
 
+"""
+    set_option(opt::String, val::Float64)
+    set_option(opt::String, val::Int)
+    set_option(opt::String, val::String)
+
+Set RME option.
+
+See RME documentation for full list of available options.
+"""
 function set_option(opt::String, val::Float64)
     @RME setOption(opt::Cstring, val::Cdouble)::Cint
 end
@@ -62,4 +71,15 @@ function set_option(opt::String, val::Int)
 end
 function set_option(opt::String, val::String)
     @RME setOptionText(opt::Cstring, val::Cstring)::Cint
+end
+
+"""
+    run_init()::Nothing
+
+Convenience function to initialize RME runs.
+"""
+function run_init()::Nothing
+    @RME runInit()::Cint
+
+    return nothing
 end


### PR DESCRIPTION
Expanded documentation and added:

- `run_init()`
- `reef_areas()`
- `collect_rep_results!()`

ReefModEngine.jl now checks if the user-provided path is valid before attempting to associate/load RME constants.
Previously the user input was trusted. If an incorrect path was given, there was no way of correcting it and the Julia session would need to be restarted.

An alternate approach to determining deployment densities is also included:

```julia
set_outplant_deployment!("outplant_iv_2026", "iv_example", 100_000, 2026, target_reef_areas_km²)

# vs

set_outplant_deployment!("outplant_iv_2026", "iv_example", 100_000, 2026, target_reef_areas_km², 6.8)
```

The first, without a density value specified, will attempt to calculate an appropriate density for the given reef area that maintains the set simulation grid size (defaulting to 10x10 - this correlates with the RMFAST10 processing option in ReefMod Engine).

The second is the previous approach, which assumes the specified density is a hard requirement, and attempts to determine an appropriate grid size (up to 100x100) to adequately represent it. Note that longer run times should be expected with larger grid sizes.