### PR TITLE
add deployment strategy to maintain consistent seeding density

### DIFF
--- a/src/deployment.jl
+++ b/src/deployment.jl
@@ -95,8 +95,8 @@ end
     match_density(
         reef_areas::Vector{Float64},
         n_corals::Int,
-        target_density::Float64,
-        max_prop::Float64 = 0.4;
+        target_density::Float64;
+        max_prop::Float64 = 0.4,
         min_reefs::Int=1
     )::Tuple{Float64, Float64, Int}
 
@@ -122,8 +122,8 @@ Tuple
 function match_density(
     reef_areas::Vector{Float64},
     n_corals::Int,
-    target_density::Float64,
-    max_prop::Float64 = 0.4;
+    target_density::Float64;
+    max_prop::Float64 = 0.4,
     min_reefs::Int=1
 )::Tuple{Float64, Float64, Int}
 


### PR DESCRIPTION
The main method added is `match_density`.

```julia
# Possible deployment areas should be listed in order of seeding preference (ranked). 
possible_deploy_areas::Vector{Float64} = ...
n_corals::Int = 1_000_000

# count per m^2
target_density::Float64 = 1.0

# Maximum allowable proportion of a location that can be seeded. 
# 1.0 would allow the entire location to be seeded at the given location
# 0.3 or less would trigger a grid resize
max_proportion::Float64 = 0.40

# Minimum number of locations to be seeded
min_locs::Int = 1

real_density, n_locations = ReefModEngine.match_density(
    possible_deploy_areas,
    n_corals,
    target_density;
    max_prop=max_proportion,
    min_reefs=min_locs
)
```
The method essentially varies the number of locations, and proportion of location area seeding to find a combination that yields are density close to the target. It does not return combinations that would force grid resizes.

Unfortunately, this can also yield unexpected combinations.

Suppose we maintain the same target density whilst increasing the number of corals to be seeded. Intuitively, we might expect the suggested number of locations used in the deployment area to increase. However, we may find a larger proportion of location to be seeded that yields a density closer to our target density the including more locations in the deployment.

For example:

Choosing the top 5 locations with a seeding proportion area of 0.4 may yield a close seeding density to our target then choosing the top 20 locations with a seeding area of 0.1. 

To avoid this behaviour and force more locations to be selected as the number of corals to be deployed increase lower the parameter `max_prop`